### PR TITLE
TST: Adjust tolerance for geometry comparison

### DIFF
--- a/test/test_field.py
+++ b/test/test_field.py
@@ -1054,10 +1054,13 @@ def test_gars_1min_exists_for_point():
         # repeat to check cache is the same
         assert len(garsf.gars_1min) == 1
         assert str(garsf.gars_1min[0]) == "173MA4722"
-        assert str(garsf.gars_1min[0].polygon) == (
-            "POLYGON ((-93.71666666666667 42,"
-            " -93.71666666666667 42.01666666666667,"
-            " -93.73333333333333 42.01666666666667,"
-            " -93.73333333333333 42,"
-            " -93.71666666666667 42))"
+        assert garsf.gars_1min[0].polygon.equals_exact(
+            shapely.wkt.loads(
+                "POLYGON ((-93.71666666666667 42,"
+                " -93.71666666666667 42.01666666666667,"
+                " -93.73333333333333 42.01666666666667,"
+                " -93.73333333333333 42,"
+                " -93.71666666666667 42))"
+            ),
+            tolerance=0.5 * 10**-12,
         )

--- a/test/test_gars.py
+++ b/test/test_gars.py
@@ -1,4 +1,5 @@
 import pytest
+import shapely.wkt
 
 from gars_field import GARSGrid
 
@@ -67,7 +68,9 @@ def test_gars_from_latlon(lat, lon, resolution, expected_id):
     ],
 )
 def test_gars_polygon(gars_id, expected_polygon):
-    assert str(GARSGrid(gars_id).polygon) == expected_polygon
+    assert GARSGrid(gars_id).polygon.equals_exact(
+        shapely.wkt.loads(expected_polygon), tolerance=0.5 * 10**-12
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #5

Use code in `almost_equals` because it is deprecated.

- https://github.com/shapely/shapely/issues/889
- https://github.com/shapely/shapely/blob/fc55006ecac8ad7835fe1618d6d391bfe076403c/shapely/geometry/base.py#L661-L666