### PR TITLE
DEP: Support Python 3.10-3.12

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -103,4 +103,4 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add example usage
    to README.rst.
-3. The pull request should work for Python 3.8+.
+3. The pull request should work for Python 3.10+.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.10
 allow_redefinition = True
 
 [mypy-shapely.*]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,10 +16,9 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Scientific/Engineering :: GIS
@@ -35,7 +34,7 @@ project_urls =
 packages = find:
 zip_safe = False # https://mypy.readthedocs.io/en/stable/installed_packages.html
 include_package_data = True
-python_requires = >=3.8
+python_requires = >=3.10
 install_requires =
     shapely
     pyproj>=3.0.0


### PR DESCRIPTION
Python 3.9 is no longer supported in the scientific python ecosystem: https://scientific-python.org/specs/spec-0000/